### PR TITLE
Use late_command to allow sudo.

### DIFF
--- a/http/preseed.cfg
+++ b/http/preseed.cfg
@@ -85,3 +85,7 @@ d-i pkgsel/update-policy select none
 #d-i debian-installer/allow_unauthenticated string true
 
 choose-mirror-bin mirror/http/proxy string
+
+# Allow vagrant to sudo without password
+d-i preseed/late_command string echo 'vagrant ALL=(ALL) NOPASSWD: ALL' >> /target/etc/sudoers.d/vagrant \
+  ; chmod 440 /target/etc/sudoers.d/vagrant

--- a/scripts/root_setup.sh
+++ b/scripts/root_setup.sh
@@ -12,13 +12,6 @@ sudo apt-get -y -q install linux-headers-$(uname -r) build-essential dkms nfs-co
 # Install necessary dependencies
 sudo apt-get -y -q install curl wget git tmux firefox xvfb vim
 
-# Setup sudo to allow no-password sudo for "admin"
-groupadd -r admin
-usermod -a -G admin vagrant
-cp /etc/sudoers /etc/sudoers.orig
-sed -i -e '/Defaults\s\+env_reset/a Defaults\texempt_group=admin' /etc/sudoers
-sed -i -e 's/%admin ALL=(ALL) ALL/%admin ALL=NOPASSWD:ALL/g' /etc/sudoers
-
 #Install Redis
 sudo apt-get -y -q install libjemalloc1
 wget -q http://d7jrzzvab3wte.cloudfront.net/checkbot/deb/redis-server_2.6.13-1_amd64.deb


### PR DESCRIPTION
Thanks for the example. It got me started quick with packer.

These changes are for an easier and cleaner sudoers implementation. I like to leave the original sudoers file without change. It also removes the requirement that "root_setup.sh" be run first before any other scripts requiring sudo.
